### PR TITLE
DT-1053 Fix queue read

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/IndexQueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/IndexQueueService.kt
@@ -58,7 +58,7 @@ class IndexQueueService(
     return queueAttributes.attributes["ApproximateNumberOfMessages"]?.toInt() ?: 0
   }
 
-  private fun getNumberOfMessagesCurrentlyInFlight(): Int {
+  fun getNumberOfMessagesCurrentlyInFlight(): Int {
     val queueAttributes = indexAwsSqsClient.getQueueAttributes(indexQueueUrl, listOf("ApproximateNumberOfMessagesNotVisible"))
     return queueAttributes.attributes["ApproximateNumberOfMessagesNotVisible"]?.toInt() ?: 0
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/IndexQueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/IndexQueueService.kt
@@ -59,7 +59,7 @@ class IndexQueueService(
   }
 
   private fun getNumberOfMessagesCurrentlyInFlight(): Int {
-    val queueAttributes = indexAwsSqsDlqClient.getQueueAttributes(indexQueueUrl, listOf("ApproximateNumberOfMessagesNotVisible"))
+    val queueAttributes = indexAwsSqsClient.getQueueAttributes(indexQueueUrl, listOf("ApproximateNumberOfMessagesNotVisible"))
     return queueAttributes.attributes["ApproximateNumberOfMessagesNotVisible"]?.toInt() ?: 0
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/indexer/integration/health/IndexInfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/indexer/integration/health/IndexInfoTest.kt
@@ -1,6 +1,9 @@
 package uk.gov.justice.digital.hmpps.indexer.integration.health
 
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -49,6 +52,7 @@ class IndexInfoTest : IntegrationTestBase() {
       initialiseIndexStatus()
       CommunityApiExtension.communityApi.stubAllOffenderGets(10 )
       buildAndSwitchIndex(SyncIndex.GREEN, 0)
+      await untilCallTo { indexQueueService.getNumberOfMessagesCurrentlyInFlight() } matches { it == 0 }
     }
 
     @Test


### PR DESCRIPTION
Using the same SQS Client for all queues when using localstack leaves us vulnerable to this kind of error :(