### PR TITLE
DT-1039 start app without queues

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/health/IndexInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/health/IndexInfo.kt
@@ -28,8 +28,8 @@ class IndexInfo(
   override fun contribute(builder: Info.Builder) {
     try {
       builder.withDetail("index-status", indexStatusService.getIndexStatus())
-    } catch (e: NoSuchElementException) {
-      builder.withDetail("index-status", "No status exists yet")
+    } catch (e: Exception) {
+      builder.withDetail("index-status", "No status exists yet (${e.message})")
     }
     builder.withDetail("index-size", mapOf(
         GREEN to indexService.getIndexCount(GREEN),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/health/IndexInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/health/IndexInfo.kt
@@ -35,7 +35,11 @@ class IndexInfo(
         GREEN to indexService.getIndexCount(GREEN),
         BLUE to indexService.getIndexCount(BLUE)
     ))
-    builder.withDetail("offender-alias", offenderRepository.offenderAliasIsPointingAt().joinToString())
+    try {
+      builder.withDetail("offender-alias", offenderRepository.offenderAliasIsPointingAt().joinToString())
+    } catch(e: Exception) {
+      builder.withDetail("offender-alias", "Elasticsearch is not available yet ")
+    }
     builder.withDetail("index-queue-backlog", safeQueueCount())
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/IndexQueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/IndexQueueService.kt
@@ -31,8 +31,8 @@ class IndexQueueService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  val indexQueueUrl: String = indexAwsSqsClient.getQueueUrl(indexQueueName).queueUrl
-  val indexDlqUrl: String = indexAwsSqsDlqClient.getQueueUrl(indexDlqName).queueUrl
+  val indexQueueUrl: String by lazy { indexAwsSqsClient.getQueueUrl(indexQueueName).queueUrl }
+  val indexDlqUrl: String by lazy { indexAwsSqsDlqClient.getQueueUrl(indexDlqName).queueUrl }
 
   fun sendPopulateIndexMessage(index: SyncIndex) {
     val result = indexAwsSqsClient.sendMessage(SendMessageRequest(indexQueueUrl, gson.toJson(IndexMessageRequest(type = POPULATE_INDEX, index = index))))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/IndexStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/IndexStatusService.kt
@@ -14,12 +14,19 @@ class IndexStatusService(private val indexStatusRepository: IndexStatusRepositor
   }
 
   fun initialiseIndexWhenRequired(): IndexStatusService {
-      if (!indexStatusRepository.existsById("STATUS")) {
+      if (!checkIndexStatusExistsIgnoringMissingRepo()) {
         indexStatusRepository.save(IndexStatus.newIndex())
             .also { log.info("Created missing index status {}", it) }
       }
     return this
   }
+
+  private fun checkIndexStatusExistsIgnoringMissingRepo(): Boolean =
+    try {
+      indexStatusRepository.existsById("STATUS")
+    } catch (e: Exception) {
+      false
+    }
 
   fun getIndexStatus(): IndexStatus =
       indexStatusRepository.findById(INDEX_STATUS_ID).orElseThrow()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/QueueAdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/QueueAdminService.kt
@@ -30,10 +30,10 @@ class QueueAdminService(private val indexAwsSqsClient: AmazonSQS,
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  val indexQueueUrl: String = indexAwsSqsClient.getQueueUrl(indexQueueName).queueUrl
-  val indexDlqUrl: String = indexAwsSqsDlqClient.getQueueUrl(indexDlqName).queueUrl
-  val eventQueueUrl: String = eventAwsSqsClient.getQueueUrl(eventQueueName).queueUrl
-  val eventDlqUrl: String = eventAwsSqsDlqClient.getQueueUrl(eventDlqName).queueUrl
+  val indexQueueUrl: String by lazy { indexAwsSqsClient.getQueueUrl(indexQueueName).queueUrl }
+  val indexDlqUrl: String by lazy { indexAwsSqsDlqClient.getQueueUrl(indexDlqName).queueUrl }
+  val eventQueueUrl: String by lazy { eventAwsSqsClient.getQueueUrl(eventQueueName).queueUrl }
+  val eventDlqUrl: String by lazy { eventAwsSqsDlqClient.getQueueUrl(eventDlqName).queueUrl }
 
   fun clearAllIndexQueueMessages() {
     val count = indexQueueService.getNumberOfMessagesCurrentlyOnIndexQueue()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/indexer/integration/health/IndexInfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/indexer/integration/health/IndexInfoTest.kt
@@ -32,7 +32,7 @@ class IndexInfoTest : IntegrationTestBase() {
           .expectStatus()
           .isOk
           .expectBody()
-          .jsonPath("index-status").value<String> { sts -> assertThat(sts).contains("No status exists yet") }
+          .jsonPath("index-status").value<String> { assertThat(it).contains("No status exists yet") }
           .jsonPath("index-status.currentIndex").doesNotExist()
           .jsonPath("index-status.otherIndex").doesNotExist()
           .jsonPath("index-size.GREEN").isEqualTo(-1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/indexer/integration/health/IndexInfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/indexer/integration/health/IndexInfoTest.kt
@@ -32,7 +32,7 @@ class IndexInfoTest : IntegrationTestBase() {
           .expectStatus()
           .isOk
           .expectBody()
-          .jsonPath("index-status").isEqualTo("No status exists yet")
+          .jsonPath("index-status").value<String> { sts -> assertThat(sts).contains("No status exists yet") }
           .jsonPath("index-status.currentIndex").doesNotExist()
           .jsonPath("index-status.otherIndex").doesNotExist()
           .jsonPath("index-size.GREEN").isEqualTo(-1)


### PR DESCRIPTION
If localstack starts Elasticsearch *after* the Spring Boot app then the app never used to start.  Fixed by lazy loading the queue URLs to prevent exceptions being thrown during bean creation.  Spring is still unhappy but it recovers once the queues become available.