### PR TITLE
DT-1156 Use URI vars to help Spring's metrics collection

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/CommunityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/indexer/service/CommunityService.kt
@@ -20,7 +20,7 @@ class CommunityService(@Qualifier("communityApiWebClient") private val webClient
 
   fun getOffender(crn: String): Either<OffenderError, Offender> =
       webClient.get()
-          .uri("/secure/offenders/crn/${crn}/all")
+          .uri("/secure/offenders/crn/{crn}/all", crn)
           .retrieve()
           .bodyToMono(String::class.java)
           .onErrorResume(::emptyIfNotFound)


### PR DESCRIPTION
Using String replacement in a URI makes Spring metrics think that every web client call is unique, and you end up seeing a warning: "Reached the maximum number of URI tags for 'http.client.requests'. Are you using 'uriVariables'?"

Interesting explanation here: https://stackoverflow.com/a/57829115